### PR TITLE
Fixed up the "C port" of the 'KeyInjector' source code.

### DIFF
--- a/tools/PSO2KeyTools/PSO2KeyInjector/dllmain.cpp
+++ b/tools/PSO2KeyTools/PSO2KeyInjector/dllmain.cpp
@@ -37,7 +37,7 @@ const unsigned char* RSAaddr = (unsigned char*)0x33BDBE0;
 			const void* ptr = (void*)(RSAaddr + (i * 0xA0));
 
 			// Prepare the file name, then open the output file-stream:
-			#if !defined(_CRT_SECURE_NO_WARNINGS)
+			#if !defined(_CRT_SECURE_NO_WARNINGS) && defined(_MSC_VER)
 				// This is just for the sake of shutting MSVC up:
 				sprintf_s(str, 14, "SEGAKey%d.blob", i);
 				fopen_s(&outFile, str, "wb");
@@ -74,7 +74,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 			FILE* filePtr;
 			
 			// Open the public-key file.
-			#if !defined(_CRT_SECURE_NO_WARNINGS)
+			#if !defined(_CRT_SECURE_NO_WARNINGS) && defined(_MSC_VER)
 				fopen_s(&filePtr, "publickey.blob", "rb");
 			#else
 				filePtr = fopen("publickey.blob", "rb");


### PR DESCRIPTION
The following changes do compile, but they have not been tested. Some testing may be in order before you merge this. But then again, you already merged a C-compatible version without really testing it (Last time I checked, anyway) so... Merge at your own risk.

Everything I've tested was with Visual Studio 2013, and MinGW (Latest, and an older build based on GCC 3.4.5).

P.S. Someone really does need to change the extension to "_.c" instead of "_.cpp".
