### PR TITLE
Up timeout and fixup EQ_Notice to handle Windows "blank" files

### DIFF
--- a/proxy/ShipProxy.py
+++ b/proxy/ShipProxy.py
@@ -193,7 +193,7 @@ class ProxyServer(ShipProxy):
         client.set_server(self)
 
         self.reactor = reactor
-        self.reactor.connectTCP(address, port if port < 13000 else port - 1000, client)
+        self.reactor.connectTCP(address, port if port < 13000 else port - 1000, client, 60)
 
 
 class ProxyFactory(protocol.Factory):

--- a/proxy/plugins/disabled/EQ_Notice.py
+++ b/proxy/plugins/disabled/EQ_Notice.py
@@ -178,18 +178,19 @@ def check_if_EQ_old(ship):
 
 
 def EQBody(body, ship):  # 0 is ship1
-    if not body.strip() or body == "null":
+    unibody = unicode(body, 'utf-8-sig', 'replace')
+    if not unibody.strip() or unibody.strip() == "null":
         logdebug("Ship %d: no data, clearing EQ data" % (ship + 1))
         data_eq[ship] = None
         return
-    logdebug("Ship %d's Body: %s" % (ship + 1, body))
+    logdebug("Ship %d's Body: %s" % (ship + 1, unibody))
     if HTTP_Data[ship] == body:
         logdebug("Ship %d: Still have the same data" % (ship + 1))
         return  # same data, do not react on it
     logdebug("Ship %d: have the new data" % (ship + 1))
     HTTP_Data[ship] = body
 
-    data_eq[ship] = cleanup_EQ(unicode(body, 'utf-8-sig', 'replace'), ship)
+    data_eq[ship] = cleanup_EQ(unibody, ship)
 
     logdebug("Ship %d: %s@%s:%s JST" % (ship + 1, data_eq[ship], hour_eq[ship], mins_eq[ship]))
 


### PR DESCRIPTION
Let bump up the ShipProxy timeout from Twisted 30 second default to 60 seconds, this may handle cyberkitsue#155
Handle Windows "blank" files like "EF BB BF 6E  75 6C 6C"