### PR TITLE
Troubeshot connections issues

### DIFF
--- a/proxy/data/ships.py
+++ b/proxy/data/ships.py
@@ -150,28 +150,28 @@ def scrape_ship_packet(ship_ip, ship_port, destination_ip):
         s.connect((ship_ip, ship_port))
     except socket.error as e:
         log.msg("[ShipQuery] Scraping %s:%i connnect return an error: %s" % (ship_ip, ship_port, e))
-        return None
+        return packetFactory.SystemMessagePacket("Proxy: Could not connect to game server", 0x1).build()
     except Exception as e:
         log.msg("[ShipQuery] Scraping %s:%i connect return an error: %s" % (ship_ip, ship_port, sys.exc_info()[0]))
-        return None
+        return packetFactory.SystemMessagePacket("Proxy: Error connect to game server", 0x1).build()
     data = io.BytesIO()
     try:
         data.write(s.recv(4))
     except socket.error as e:
         log.msg("[ShipQuery] Scraping %s:%i recv return an error: %s" % (ship_ip, ship_port, e))
-        return None
+        return packetFactory.SystemMessagePacket("Proxy: game server dropped connection", 0x1).build()
     except Exception as e:
         log.msg("[ShipQuery] Scraping %s:%i recv return an error: %s" % (ship_ip, ship_port, sys.exc_info()[0]))
-        return None
+        return packetFactory.SystemMessagePacket("Proxy: game server dropped connection due to error", 0x1).build()
     actual_size = struct.unpack_from('i', data.getvalue(), 0x0)[0]
     try:
         data.write(s.recv(actual_size - 4))
     except socket.error as e:
         log.msg("[ShipQuery] Scraping %s:%i write return an error: %s" % (ship_ip, ship_port, e))
-        return None
+        return packetFactory.SystemMessagePacket("Proxy: game server dropped connection midway", 0x1).build()
     except Exception as e:
         log.msg("[ShipQuery] Scraping %s:%i wrtie return an error: %s" % (ship_ip, ship_port, sys.exc_info()[0]))
-        return None
+        return packetFactory.SystemMessagePacket("Proxy: game server dropped connection midway due to error", 0x1).build()
     s.close()
     data.flush()
     data = bytearray(data.getvalue())


### PR DESCRIPTION
Send error messages back to the connection players
And allow one to turn off and on the whitelist plugin, useful when reopen the proxy to the flood of incoming player connections