### PR TITLE
Filter commands and add a command

### DIFF
--- a/proxy/commands.py
+++ b/proxy/commands.py
@@ -124,17 +124,49 @@ class HelpCommand(Command):
         user_command_count = 0
         for command, cData in commandList.iteritems():
             if cData[1] is not None:
-                user_command_count += 1
-                string += "%s%s - %s\n\n" % (config.globalConfig.get_key('commandPrefix'), command, cData[1])
+                if cData[2] is not None:
+                    if not cData[2]:
+                        user_command_count += 1
+                        string += "%s%s - %s\n\n" % (config.globalConfig.get_key('commandPrefix'), command, cData[1])
+                else:
+                    user_command_count += 1
+                    string += "%s%s - %s\n\n" % (config.globalConfig.get_key('commandPrefix'), command, cData[1])
         for command, cData in plugin_manager.commands.iteritems():
             if cData[1] is not None:
-                user_command_count += 1
-                string += "%s%s - %s\n\n" % (config.globalConfig.get_key('commandPrefix'), command, cData[1])
+                if cData[2] is not None:
+                    if not cData[2]:
+                        user_command_count += 1
+                        string += "%s%s - %s\n\n" % (config.globalConfig.get_key('commandPrefix'), command, cData[1])
+                else:
+                    user_command_count += 1
+                    string += "%s%s - %s\n\n" % (config.globalConfig.get_key('commandPrefix'), command, cData[1])
+        string += "%ssuhelp - [Admin Only] Display proxy administrator command list.\n\n" % config.globalConfig.get_key('commandPrefix') #i add this manually because don't know how to get specific command.
         string += "=== %i commands in total ===" % user_command_count
         client.send_crypto_packet(packetFactory.SystemMessagePacket(string, 0x2).build())
 
     def call_from_console(self):
         return "=== PSO2Proxy Commands ===\n -- %s\n -- %s\n=== PSO2Proxy Commands ===" % ('\n -- '.join(commandList.keys()), '\n -- '.join(plugin_manager.commands.keys()))
+
+
+@CommandHandler("suhelp", "[Admin Only] Display proxy administrator command list.", True)
+class HelpCommandADM(Command):
+    def call_from_client(self, client):
+        string = "=== PSO2Proxy Commands ===\n"
+        user_command_count = 0
+        for command, cData in commandList.iteritems():
+            if cData[1] is not None:
+                if cData[2] is not None:
+                    if cData[2]:
+                        user_command_count += 1
+                        string += "%s%s - %s\n\n" % (config.globalConfig.get_key('commandPrefix'), command, cData[1])
+        for command, cData in plugin_manager.commands.iteritems():
+            if cData[1] is not None:
+                if cData[2] is not None:
+                    if cData[2]:
+                        user_command_count += 1
+                        string += "%s%s - %s\n\n" % (config.globalConfig.get_key('commandPrefix'), command, cData[1])
+        string += "=== %i commands in total ===" % user_command_count
+        client.send_crypto_packet(packetFactory.SystemMessagePacket(string, 0x2).build())
 
 
 @CommandHandler("count", "Prints number of connected clients.")

--- a/proxy/commands.py
+++ b/proxy/commands.py
@@ -122,7 +122,7 @@ class HelpCommand(Command):
     def call_from_client(self, client):
         string = "=== PSO2Proxy Commands ===\n"
         user_command_count = 0
-        for command, cData in commandList.iteritems():
+        for command, cData in sorted(commandList.iteritems()):
             if cData[1] is not None:
                 if cData[2] is not None:
                     if not cData[2]:
@@ -131,7 +131,7 @@ class HelpCommand(Command):
                 else:
                     user_command_count += 1
                     string += "%s%s - %s\n\n" % (config.globalConfig.get_key('commandPrefix'), command, cData[1])
-        for command, cData in plugin_manager.commands.iteritems():
+        for command, cData in sorted(plugin_manager.commands.iteritems()):
             if cData[1] is not None:
                 if cData[2] is not None:
                     if not cData[2]:
@@ -153,13 +153,13 @@ class HelpCommandADM(Command):
     def call_from_client(self, client):
         string = "=== PSO2Proxy Commands ===\n"
         user_command_count = 0
-        for command, cData in commandList.iteritems():
+        for command, cData in sorted(commandList.iteritems()):
             if cData[1] is not None:
                 if cData[2] is not None:
                     if cData[2]:
                         user_command_count += 1
                         string += "%s%s - %s\n\n" % (config.globalConfig.get_key('commandPrefix'), command, cData[1])
-        for command, cData in plugin_manager.commands.iteritems():
+        for command, cData in sorted(plugin_manager.commands.iteritems()):
             if cData[1] is not None:
                 if cData[2] is not None:
                     if cData[2]:


### PR DESCRIPTION
Filter commands for in-game proxy user (at "help"). *in-console, show all commands.
And add a command for in-game proxy administrator (at "suhelp"). *exclude at console.

At "help", Proxy users really no need to know about proxy administrator commands. :/
At line 143, i add this manually because i don't know how to get specific command.